### PR TITLE
feat: 상세 페이지 컴포넌트 추가

### DIFF
--- a/bablog-front/src/components/DetailPage.jsx
+++ b/bablog-front/src/components/DetailPage.jsx
@@ -1,0 +1,14 @@
+import TitleSection from './TitleSection';
+import ImageSection from './ImageSection';
+import ReviewSection from './ReviewSection';
+import '../styles/DetailPage.css';
+
+const DetailPage = ({ detailData }) => (
+  <div className="detail-page">
+    <TitleSection data={detailData} />
+    <ImageSection imageUrl={detailData.imageUrl} />
+    <ReviewSection postId={detailData.postId} userId={detailData.userId} />
+  </div>
+);
+
+export default DetailPage;

--- a/bablog-front/src/components/Header.jsx
+++ b/bablog-front/src/components/Header.jsx
@@ -5,6 +5,7 @@ const Header = () => {
   const navigate = useNavigate();
 
   const handleLogout = () => {
+    if (!window.confirm('정말 로그아웃 하시겠습니까?')) return;
     localStorage.removeItem('token');
     navigate('/login');
   };

--- a/bablog-front/src/components/ImageSection.jsx
+++ b/bablog-front/src/components/ImageSection.jsx
@@ -1,0 +1,7 @@
+const ImageSection = ({ imageUrl }) => (
+  <section className="image-section">
+    <img src={imageUrl} alt="대표 이미지" className="main-image" />
+  </section>
+);
+
+export default ImageSection;

--- a/bablog-front/src/components/TitleSection.jsx
+++ b/bablog-front/src/components/TitleSection.jsx
@@ -1,0 +1,8 @@
+const TitleSection = ({ data }) => (
+  <section className="title-section">
+    <h2>{data.title}</h2>
+    <p className="description">{data.description}</p>
+  </section>
+);
+
+export default TitleSection;

--- a/bablog-front/src/pages/Detail.jsx
+++ b/bablog-front/src/pages/Detail.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import DetailPage from '../components/DetailPage';
+
+const Detail = () => {
+  const { postId } = useParams();
+  const [detailData, setDetailData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/post/${postId}`)
+      .then(res => {
+        if (!res.ok) throw new Error('Network response was not ok');
+        return res.json();
+      })
+      .then(data => {
+        setDetailData(data);
+      })
+      .catch(() => {
+        // 목업 데이터
+        setDetailData({
+          title: '맛있는 한식',
+          description: '서울 강남구 도로명 상세주소 어쩌구',
+          imageUrl:
+            'https://images.unsplash.com/photo-1504674900247-0877df9cc836',
+          reviews: [
+            {
+              id: 1,
+              author: 'test@naver.com',
+              date: '2024-05-07',
+              content: '정말 맛있어 보여요!',
+              liked: true,
+            },
+            {
+              id: 2,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 3,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 4,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 5,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 6,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 7,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 8,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 9,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 10,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+            {
+              id: 11,
+              author: 'test2@naver.com',
+              date: '2024-05-07',
+              content: '한식은 사랑입니다.',
+              liked: false,
+            },
+          ],
+        });
+        setError('데이터를 불러오지 못했습니다. (mock data)');
+      })
+      .finally(() => setLoading(false));
+  }, [postId]);
+
+  if (loading) return <div>로딩중...</div>;
+  if (!detailData) return <div>데이터 없음</div>;
+
+  return (
+    <div>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      <DetailPage detailData={detailData} />
+    </div>
+  );
+};
+
+export default Detail;


### PR DESCRIPTION
- 헤더 로그아웃 부분 경고설정
- 상세 페이지 기본 틀 컴포넌트 추가 ( 타이틀, 이미지 )
- 상세 페이지 api 연결 및 목업 데이터 추가 // 임시 데이터 나중에 삭제 예정