### PR TITLE
feat: 리뷰 삭제 API 개발

### DIFF
--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/ReviewController.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/ReviewController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import kr.bablog.bablogbe.reviews.controller.dto.request.ReviewCommentUpdateWebR
 import kr.bablog.bablogbe.reviews.controller.dto.request.ReviewCreateWebRequest;
 import kr.bablog.bablogbe.reviews.controller.dto.response.ReviewCommentUpdateWebResponse;
 import kr.bablog.bablogbe.reviews.controller.dto.response.ReviewCreateWebResponse;
+import kr.bablog.bablogbe.reviews.controller.dto.response.ReviewDeleteWebResponse;
 import kr.bablog.bablogbe.reviews.controller.dto.response.ReviewLookUpWebResponse;
 import kr.bablog.bablogbe.reviews.controller.dto.response.ReviewLookUpWebResponses;
 import kr.bablog.bablogbe.reviews.service.ReviewService;
@@ -74,7 +76,8 @@ public class ReviewController {
 			throw new ReviewInvalidRequestException(ReviewErrorType.REVIEW_INVALID_SIZE);
 		}
 
-		final ReviewLookupResponses reviewLookupResponses = reviewService.findPagedReviewsByPostId(postId, offset, size);
+		final ReviewLookupResponses reviewLookupResponses = reviewService.findPagedReviewsByPostId(postId, offset,
+			size);
 
 		final List<ReviewLookUpWebResponse> reviewLookUpWebResponses =
 			reviewLookupResponses.reviewLookupResponses().stream()
@@ -83,5 +86,14 @@ public class ReviewController {
 
 		return ResponseEntity.ok(ApiResponse.success(new ReviewLookUpWebResponses(reviewLookUpWebResponses,
 			reviewLookupResponses.reviewCount(), reviewLookupResponses.likeCount())));
+	}
+
+	// TODO 본인이 작성한 리뷰에 한해서 코멘트 삭제 기능 추가
+	@DeleteMapping("/reviews/{reviewId}")
+	public ResponseEntity<ApiResponse<ReviewDeleteWebResponse>> deleteReview(
+		@PathVariable(name = "reviewId") final Long reviewId) {
+		Long deleteReviewId = reviewService.deleteReview(reviewId);
+		final ReviewDeleteWebResponse reviewDeleteWebResponse = new ReviewDeleteWebResponse(deleteReviewId);
+		return ResponseEntity.ok(ApiResponse.success(reviewDeleteWebResponse));
 	}
 }

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/dto/response/ReviewDeleteWebResponse.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/dto/response/ReviewDeleteWebResponse.java
@@ -1,0 +1,4 @@
+package kr.bablog.bablogbe.reviews.controller.dto.response;
+
+public record ReviewDeleteWebResponse(Long deletedId) {
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/repository/QueryDslReviewRepository.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/repository/QueryDslReviewRepository.java
@@ -87,4 +87,9 @@ public class QueryDslReviewRepository implements ReviewRepository {
 			.where(review.postId.eq(postId).and(review.reviewLike.eq(Boolean.TRUE)))
 			.fetchOne();
 	}
+
+	@Override
+	public void deleteById(final Long reviewId) {
+		jpaReviewRepository.deleteById(reviewId);
+	}
 }

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/service/ReviewService.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/service/ReviewService.java
@@ -34,6 +34,7 @@ public class ReviewService {
 		return reviewRepository.save(reviewCreateWebRequest.toServiceRequest());
 	}
 
+	// TODO 본인이 작성한 리뷰에 한해서 코멘트 변경 기능
 	@Transactional
 	public ReviewCommentUpdateResponse updateComment(final ReviewCommentUpdateRequest reviewCommentUpdateRequest) {
 		final Long inputReviewId = reviewCommentUpdateRequest.reviewId();
@@ -56,5 +57,21 @@ public class ReviewService {
 		final Long reviewLikeCount = reviewRepository.countReviewLikeByPostId(postId);
 
 		return new ReviewLookupResponses(reviewLookupResponses, reviewCount, reviewLikeCount);
+	}
+
+	/**
+	 *
+	 * @param reviewId 삭제할 리뷰 아이디
+	 * @return 삭제한 리뷰 아이디 반환
+	 */
+	// TODO 본인이 작성한 리뷰에 한해서 삭제 기능 + 본인이 아닌 경우 예외 반환 로직 추가
+	@Transactional
+	public Long deleteReview(final Long reviewId) {
+		final Review review = reviewRepository.findEntityById(reviewId)
+			.orElseThrow(() -> new ReviewNotFoundException(ReviewErrorType.REVIEW_NOT_FOUND));
+
+		reviewRepository.deleteById(review.getId());
+
+		return review.getId();
 	}
 }

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/service/repository/ReviewRepository.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/service/repository/ReviewRepository.java
@@ -15,4 +15,5 @@ public interface ReviewRepository {
 	List<ReviewLookupResponse> findPagedReviewsByPostId(Long postId, int offset, int limit);
 	Long countReviewByPostId(Long postId);
 	Long countReviewLikeByPostId(Long postId);
+	void deleteById(Long reviewId);
 }


### PR DESCRIPTION
## 작업 내용

- 리뷰 식별자를 기준으로 리뷰 삭제 기능입니다.
- 리뷰 삭제 성공 시, 삭제한 리뷰 식별자 반환합니다. 
- [ ] TODO
    - 사용자 본인에 한해 삭제 기능 추가가 필요합니다.
    - 회원 도메인 로직 병합 후 진행할 예정입니다.


## Request

### 

## Response

### 정상 응답

```text
HTTP/1.1 200 
Content-Type: application/json

{
  "result": "SUCCESS",
  "data": {
    "deletedId": 1
  },
  "error": null
}
```

### 리뷰 아이디가 존재하지 않는 경우

```text
HTTP/1.1 400 
Content-Type: application/json

{
  "result": "ERROR",
  "data": null,
  "error": {
    "code": "ERROR_REVIEW03",
    "message": "리뷰가 존재하지 않습니다",
    "data": null
  }
}
```