### PR TITLE
refactor: 리뷰 이메일 필드 더미 방식 임시 변경

### DIFF
--- a/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/dto/response/ReviewLookUpWebResponse.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/reviews/controller/dto/response/ReviewLookUpWebResponse.java
@@ -2,12 +2,12 @@ package kr.bablog.bablogbe.reviews.controller.dto.response;
 
 import kr.bablog.bablogbe.reviews.service.dto.response.ReviewLookupResponse;
 
-public record ReviewLookUpWebResponse(Long reviewId, String comment, Long userId, boolean like) {
+public record ReviewLookUpWebResponse(Long reviewId, String comment, String email, boolean like) {
 	public static ReviewLookUpWebResponse from(ReviewLookupResponse reviewLookupResponse) {
 		return new ReviewLookUpWebResponse(
 			reviewLookupResponse.reviewId(),
 			reviewLookupResponse.comment(),
-			reviewLookupResponse.userId(),
+			"test@gmail.com", // TODO email 필드 주입 변경
 			reviewLookupResponse.like());
 	}
 }


### PR DESCRIPTION
## History
- 회원 도메인 통합 이전에 userId 설정 진행
- 이메일 필드 변경을 위한 커밋
- 클라이언트 테스트를 위한 이메일 더미 데이터 추가

## Response 

### 응답 형식

```text
HTTP/1.1 200 
Content-Type: application/json

{
  "result": "SUCCESS",
  "data": {
    "reviews": [
      {
        "reviewId": 1,
        "comment": "사용자 코멘트",
        "email": "test@gmail.com", // 해당 필드 샘플 더미 추가
        "like": true
      }
    ],
    "reviewCount": 1,
    "likeCount": 1
  },
  "error": null
}
```
