### PR TITLE
feat: 밥집 api 예외처리 추가

### DIFF
--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/controller/PostController.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/controller/PostController.java
@@ -25,10 +25,10 @@ public class PostController {
 
     @GetMapping("/posts")
     public ApiResponse<PostListResponseDto> getPostList(
-            @RequestParam(value = "offset", defaultValue = "0") int offset
-        , @RequestParam(value = "limit", defaultValue = "9") int limit) {
+            @RequestParam(value = "offset", defaultValue = "0") Long offset
+        , @RequestParam(value = "limit", defaultValue = "9") Long limit) {
 
-        Page<Post> postPage = this.postService.getPostList(offset, limit);
+        Page<Post> postPage = this.postService.getPostList(offset.intValue(), limit.intValue());
 
         //todo: builder패턴으로
         List<PostResponseDto> postListDto = postPage.getContent().stream()

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/controller/error/handler/PostControllerAdvice.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/controller/error/handler/PostControllerAdvice.java
@@ -1,0 +1,35 @@
+package kr.bablog.bablogbe.post.controller.error.handler;
+
+import kr.bablog.bablogbe.common.api.response.ApiResponse;
+import kr.bablog.bablogbe.post.service.errors.PostErrorType;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import java.util.NoSuchElementException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class PostControllerAdvice {
+
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatch() {
+        final PostErrorType errorType = PostErrorType.ARGUMENT_MISSMATCH;
+        
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(errorType.getPostErrorCode().toString(), errorType.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ApiResponse<?>> handleNoSuchElement() {
+        final PostErrorType errorType = PostErrorType.NOSUCH_ELEMENT;
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(errorType.getPostErrorCode().toString(), errorType.getMessage()));
+    }
+
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/NoSuchElement.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/NoSuchElement.java
@@ -1,0 +1,7 @@
+package kr.bablog.bablogbe.post.service.errors;
+
+public class NoSuchElement extends PostException {
+    public NoSuchElement(PostErrorType postErrorType) {
+        super(postErrorType);
+    }
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostErrorCode.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostErrorCode.java
@@ -1,0 +1,8 @@
+package kr.bablog.bablogbe.post.service.errors;
+
+
+public enum PostErrorCode {
+    ERROR_POST01,
+    ERROR_POST02
+
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostErrorType.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostErrorType.java
@@ -1,0 +1,14 @@
+package kr.bablog.bablogbe.post.service.errors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostErrorType {
+    ARGUMENT_MISSMATCH(PostErrorCode.ERROR_POST01, "잘못된 접근입니다"),
+    NOSUCH_ELEMENT(PostErrorCode.ERROR_POST02, "요청받은 리소스를 찾을 수 없습니다");
+
+    private final PostErrorCode postErrorCode;
+    private final String message;
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostException.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/PostException.java
@@ -1,0 +1,14 @@
+package kr.bablog.bablogbe.post.service.errors;
+
+
+import lombok.Getter;
+
+@Getter
+public abstract class PostException extends RuntimeException{
+    private final PostErrorType errorType;
+
+    public PostException(final PostErrorType postErrorType) {
+        super(postErrorType.getMessage());
+        this.errorType = postErrorType;
+    }
+}

--- a/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/TypeMismatch.java
+++ b/bablog-be/src/main/java/kr/bablog/bablogbe/post/service/errors/TypeMismatch.java
@@ -1,0 +1,7 @@
+package kr.bablog.bablogbe.post.service.errors;
+
+public class TypeMismatch extends PostException {
+    public TypeMismatch(PostErrorType postErrorType) {
+        super(postErrorType);
+    }
+}


### PR DESCRIPTION
## 서버에 없는 자원을 요청할시
### Request  
/api/post/3


### Response
```
{
    "result": "ERROR",
    "data": null,
    "error": {
        "code": "ERROR_POST02",
        "message": "요청받은 리소스를 찾을 수 없습니다",
        "data": null
    }
}
```

## url쿼리스트링 값에 알맞은 형태의 값이 아닐떄
### Request
```
/api/posts?limit=5&offset=abc
```

### Response
```
{
    "result": "ERROR",
    "data": null,
    "error": {
        "code": "ERROR_POST01",
        "message": "잘못된 접근입니다",
        "data": null
    }
}
```